### PR TITLE
Update and improve tests

### DIFF
--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -1023,6 +1023,7 @@ class WasmModuleBuilder {
                 section.emit_u32v(global.function_index);
               } else {
                 section.emit_u8(kExprRefNull);
+                section.emit_u8(kWasmAnyRef);
               }
               break;
             }


### PR DESCRIPTION
- Update tests that relied on the old API, where export wrappers were allowed to return "non-promisified" results.
- Add new tests ported from the V8 test suite
- Avoid dependency on wasm exception handling