### PR TITLE
Modify spec to use Promise.resolve on result of call to suspending function.

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -42,7 +42,8 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: PromiseCapabilityRecord; url: sec-promisecapability-records
         text: EvaluateCall; url: sec-evaluatecall
         text: ExecutionContext; url: sec-execution-contexts
-        text: IsPromise; url: sec-ispromise
+        text: Promise; url: sec-promise-constructor
+        text: PromiseResolve; url: sec-promise-resolve
         text: PerformPromiseThen; url: sec-performpromisethen
         text: Execution Context Stack; url: execution-context-stack
     type: dfn
@@ -1488,11 +1489,10 @@ To <dfn>create a suspending function</dfn> from a JavaScript function |func|, wi
         1. If |ret|.\[[Type]] is <emu-const>throw</emu-const>, then:
             1. Let |type|, |payload| and |opaqueData| be the result of [=coerce a JavaScript exception|coercing the JavaScript exception=] |ret|.\[[Value]].
             1. [=WebAssembly/Throw=] with |type|, |payload| and |opaqueData|.
-        1. Otherwise, if [=list/size=] of |ret| is 1 and [$IsPromise$](|ret|.\[[Value]][0]):
-            1. Let |promise| be |ret|.\[[Value]][0].
+        1. Otherwise,
+            1. Let |promise| be [=?=] [$PromiseResolve$]({{%Promise%}},|ret|.\[[Value]]).
             1. Set the entry for |async_context| in |map| to [=paused=].
             1. Let |awaitResult| be the result of performing [$Completion$]([$Await$](|promise|)).
-            1. Note: We only invoke [$Await$] if the call to |func| has returned a Promise object.
             1. Note: This will suspend both this algorithm, and the WebAssembly function being invoked by the [=evaluate a Promising function=] algorithm. On return, |ret| will be either a normal completion or a throw completion.
             1. If the entry for |async_context| in |map| is not [=paused=] then:
                 1. Perform [=throw a JavaScript exception=] with a {{RuntimeError}}.
@@ -1501,7 +1501,6 @@ To <dfn>create a suspending function</dfn> from a JavaScript function |func|, wi
                1. Let |type|, |payload| and |opaqueData| be the result of [=coerce a JavaScript exception|coercing the JavaScript exception=] |ret|.\[[Value]].
                1. [=WebAssembly/Throw=] with |type|, |payload| and |opaqueData|.
             1. Otherwise, return the result of performing [=coerce a JavaScript return=] on |resultTypes| and |awaitResult|.
-        1. Otherwise, return the result of performing [=coerce a JavaScript return=] on |resultTypes| and |ret|.
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let (|store|, |funcaddr|) be [=func_alloc=](|store|, |functype|, |hostfunc|).
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1501,7 +1501,7 @@ To <dfn>create a suspending function</dfn> from a JavaScript function |func|, wi
                 1. Let |awaitResult| be the result of performing [$Completion$]([$Await$](|promise|)).
                 1. Note: This will suspend both this algorithm, and the WebAssembly function being invoked by the [=evaluate a Promising function=] algorithm. On return, |ret| will be either a normal completion or a throw completion.
                 1. If the entry for |async_context| in |map| is not [=paused=] then:
-                    1. Perform [=throw a JavaScript exception=] with a {{RuntimeError}}.
+                    1. Perform [=throw a JavaScript exception=] with a {{SuspendError}}.
                 1. Otherwise, set the entry to [=active=].
                 1. If |awaitResult|.\[[Type]] is <emu-const>throw</emu-const>, then:
                    1. Let |type|, |payload| and |opaqueData| be the result of [=coerce a JavaScript exception|coercing the JavaScript exception=] |ret|.\[[Value]].

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1490,17 +1490,23 @@ To <dfn>create a suspending function</dfn> from a JavaScript function |func|, wi
             1. Let |type|, |payload| and |opaqueData| be the result of [=coerce a JavaScript exception|coercing the JavaScript exception=] |ret|.\[[Value]].
             1. [=WebAssembly/Throw=] with |type|, |payload| and |opaqueData|.
         1. Otherwise,
-            1. Let |promise| be [=?=] [$PromiseResolve$]({{%Promise%}},|ret|.\[[Value]]).
-            1. Set the entry for |async_context| in |map| to [=paused=].
-            1. Let |awaitResult| be the result of performing [$Completion$]([$Await$](|promise|)).
-            1. Note: This will suspend both this algorithm, and the WebAssembly function being invoked by the [=evaluate a Promising function=] algorithm. On return, |ret| will be either a normal completion or a throw completion.
-            1. If the entry for |async_context| in |map| is not [=paused=] then:
-                1. Perform [=throw a JavaScript exception=] with a {{RuntimeError}}.
-            1. Otherwise, set the entry to [=active=].
-            1. If |awaitResult|.\[[Type]] is <emu-const>throw</emu-const>, then:
-               1. Let |type|, |payload| and |opaqueData| be the result of [=coerce a JavaScript exception|coercing the JavaScript exception=] |ret|.\[[Value]].
-               1. [=WebAssembly/Throw=] with |type|, |payload| and |opaqueData|.
-            1. Otherwise, return the result of performing [=coerce a JavaScript return=] on |resultTypes| and |awaitResult|.
+            1. Let |prRet| be the result of [$PromiseResolve$]({{%Promise%}},|ret|.\[[Value]]).
+            1. Assert: |prRet|.\[[Type]] is <emu-const>throw</emu-const> or <emu-const>normal</emu-const>.
+            1. If |prRet|.\[[Type]] is <emu-const>throw</emu-const>, then:
+                1. Let |type|, |payload| and |opaqueData| be the result of [=coerce a JavaScript exception|coercing the JavaScript exception=] |ret|.\[[Value]].
+                1. [=WebAssembly/Throw=] with |type|, |payload| and |opaqueData|.
+            1. Otherwise,
+                1. Let |promise| be |prRet|.\[[Value]].
+                1. Set the entry for |async_context| in |map| to [=paused=].
+                1. Let |awaitResult| be the result of performing [$Completion$]([$Await$](|promise|)).
+                1. Note: This will suspend both this algorithm, and the WebAssembly function being invoked by the [=evaluate a Promising function=] algorithm. On return, |ret| will be either a normal completion or a throw completion.
+                1. If the entry for |async_context| in |map| is not [=paused=] then:
+                    1. Perform [=throw a JavaScript exception=] with a {{RuntimeError}}.
+                1. Otherwise, set the entry to [=active=].
+                1. If |awaitResult|.\[[Type]] is <emu-const>throw</emu-const>, then:
+                   1. Let |type|, |payload| and |opaqueData| be the result of [=coerce a JavaScript exception|coercing the JavaScript exception=] |ret|.\[[Value]].
+                   1. [=WebAssembly/Throw=] with |type|, |payload| and |opaqueData|.
+                1. Otherwise, return the result of performing [=coerce a JavaScript return=] on |resultTypes| and |awaitResult|.
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let (|store|, |funcaddr|) be [=func_alloc=](|store|, |functype|, |hostfunc|).
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.


### PR DESCRIPTION
This modifies the specification:

All calls to functions that are marked as Suspending will be processed using Promise.resolve.

Note that, if the callee throws, then that throw is NOT converted to a Promise. In part, this is because we cannot reliably invoke Promise.reject in all cases (e.g., stack overflow errors).